### PR TITLE
fix: 解决新建容器时，添加端口无法设置udp模式的bug

### DIFF
--- a/src/client/app/pages/group/server/container-new/container-new.html
+++ b/src/client/app/pages/group/server/container-new/container-new.html
@@ -140,7 +140,7 @@
             </div>
           </div>
           <div class="form-group">
-            <select class="form-control">
+            <select class="form-control" formControlName="Type">
               <option value="tcp">TCP</option>
               <option value="udp">UDP</option>
             </select>


### PR DESCRIPTION
在feature/1.4.0分支的基础上，修改的该bug。在master分支，我使用原先的代码无法正常启动程序，故没在master分支上修改。