### PR TITLE
修复了私有仓库带端口和外网访问agent无法访问问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,14 @@ FROM node:8.11-alpine
 
 MAINTAINER Bob Liu <Bobliu0909@gmail.com>
 
-ADD humpback-web /humpback-web
+ADD dist /humpback-web
+ADD package.json /humpback-web/package.json
+ADD package-lock.json /humpback-web/package-lock.json
 
 WORKDIR /humpback-web
+
+RUN npm config set registry https://registry.npm.taobao.org
+RUN npm config set strict-ssl false
+RUN npm install --production
 
 CMD ["node", "index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha1-+mYYmaik44y3xYPHpcl85l1ZKjU=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/common": {
@@ -19,7 +19,7 @@
             "integrity": "sha1-S4FCByTggooOg5uVpV6xp+g5GPI=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/compiler": {
@@ -28,7 +28,7 @@
             "integrity": "sha1-LuH68lt1fh0SiXkHS+f65SmzvCA=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/core": {
@@ -37,7 +37,7 @@
             "integrity": "sha1-EwMf0Q3P5DiHVBmzjyESCVi8I1Q=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/forms": {
@@ -46,7 +46,7 @@
             "integrity": "sha1-/mSs5CQ1wbgPSQNLfEHOjK8UpEo=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/http": {
@@ -55,7 +55,7 @@
             "integrity": "sha1-CvaAxnEL3AJtlA4iXP0PalwAXQw=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/platform-browser": {
@@ -64,7 +64,7 @@
             "integrity": "sha1-qYOcVH4bZU+h0kqJeAyLpquNzOA=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/platform-browser-dynamic": {
@@ -73,7 +73,7 @@
             "integrity": "sha1-TT2aanvyzz3kBYphWuBZ7/ZB+jY=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/router": {
@@ -82,7 +82,7 @@
             "integrity": "sha1-D2rSmuD/jSyeo3m9MgRHIXt+yGY=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angularclass/resolve-angular-routes": {
@@ -112,7 +112,7 @@
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "7.0.58"
+                "@types/node": "*"
             }
         },
         "@types/jasmine": {
@@ -142,10 +142,10 @@
             "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
             "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "requires": {
-                "@types/caseless": "0.12.1",
-                "@types/form-data": "2.2.1",
-                "@types/node": "7.0.58",
-                "@types/tough-cookie": "2.3.2"
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
             }
         },
         "@types/select2": {
@@ -154,7 +154,7 @@
             "integrity": "sha1-w9/fk7/ztC4wRw/8lDLh1UcxmqA=",
             "dev": true,
             "requires": {
-                "@types/jquery": "2.0.49"
+                "@types/jquery": "*"
             }
         },
         "@types/tough-cookie": {
@@ -167,7 +167,7 @@
             "resolved": "http://r.cnpmjs.org/accepts/download/accepts-1.3.5.tgz",
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "requires": {
-                "mime-types": "2.1.18",
+                "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
             }
         },
@@ -183,7 +183,7 @@
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13"
+                "acorn": "^4.0.3"
             },
             "dependencies": {
                 "acorn": {
@@ -200,10 +200,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -218,9 +218,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -229,7 +229,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -246,7 +246,7 @@
             "integrity": "sha1-wNROkP/w+sleiyPwQ6zaf9HFHXw=",
             "dev": true,
             "requires": {
-                "loader-utils": "0.2.17"
+                "loader-utils": "^0.2.15"
             }
         },
         "ansi-colors": {
@@ -255,7 +255,7 @@
             "integrity": "sha1-Y3S03V1HGP884npnGjscrQdxMqk=",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-gray": {
@@ -295,8 +295,8 @@
             "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             }
         },
         "append-buffer": {
@@ -305,7 +305,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "aproba": {
@@ -380,7 +380,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -407,9 +407,9 @@
             "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -456,12 +456,12 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000821",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^1.7.6",
+                "caniuse-db": "^1.0.30000634",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^5.2.16",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "awesome-typescript-loader": {
@@ -470,13 +470,13 @@
             "integrity": "sha1-TU0Qy6egTtQz36AzQlCEb7EaGlo=",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "^2.3.1",
                 "enhanced-resolve": "3.3.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.5",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.4"
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.4",
+                "micromatch": "^3.0.3",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -485,7 +485,7 @@
                     "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -494,9 +494,9 @@
                     "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "loader-utils": {
@@ -505,9 +505,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "supports-color": {
@@ -516,7 +516,7 @@
                     "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -527,9 +527,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "balanced-match": {
@@ -544,13 +544,13 @@
             "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -559,7 +559,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -593,7 +593,7 @@
             "resolved": "http://r.cnpmjs.org/binary-search-tree/download/binary-search-tree-0.2.5.tgz",
             "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
             "requires": {
-                "underscore": "1.4.4"
+                "underscore": "~1.4.4"
             }
         },
         "bluebird": {
@@ -614,15 +614,15 @@
             "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.15"
             }
         },
         "boolbase": {
@@ -642,7 +642,7 @@
             "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -652,18 +652,18 @@
             "integrity": "sha1-cIbJE7TloI2+N6wO5qJQDEumkbs=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "kind-of": "6.0.2",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "kind-of": "^6.0.2",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -672,7 +672,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -681,7 +681,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -698,12 +698,12 @@
             "integrity": "sha1-OLerVe24Bv8tzaGn8WIHc6R3xJ8=",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -712,9 +712,9 @@
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.1.1",
-                "browserify-des": "1.0.0",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -723,9 +723,9 @@
             "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "browserify-rsa": {
@@ -734,8 +734,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -744,13 +744,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.0"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -759,7 +759,7 @@
             "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             }
         },
         "browserslist": {
@@ -768,8 +768,8 @@
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "dev": true,
             "requires": {
-                "caniuse-db": "1.0.30000821",
-                "electron-to-chromium": "1.3.41"
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
             }
         },
         "buffer": {
@@ -778,9 +778,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.2.3",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -831,19 +831,19 @@
             "integrity": "sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.2",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.3.0",
-                "unique-filename": "1.1.0",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
             }
         },
         "cache-base": {
@@ -852,15 +852,15 @@
             "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "camel-case": {
@@ -869,8 +869,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "camelcase": {
@@ -883,8 +883,8 @@
             "resolved": "http://r.cnpmjs.org/camelcase-keys/download/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
             }
         },
         "caniuse-api": {
@@ -893,10 +893,10 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000821",
-                "lodash.memoize": "4.1.2",
-                "lodash.uniq": "4.5.0"
+                "browserslist": "^1.3.6",
+                "caniuse-db": "^1.0.30000529",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
             }
         },
         "caniuse-db": {
@@ -911,8 +911,8 @@
             "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
             "dev": true,
             "requires": {
-                "ansicolors": "0.2.1",
-                "redeyed": "1.0.1"
+                "ansicolors": "~0.2.1",
+                "redeyed": "~1.0.0"
             }
         },
         "center-align": {
@@ -921,8 +921,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -930,11 +930,11 @@
             "resolved": "http://r.cnpmjs.org/chalk/download/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "chokidar": {
@@ -943,18 +943,18 @@
             "integrity": "sha1-3L1PbLsqVbR5m6ioQKxSfl9LEXY=",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.1",
-                "fsevents": "1.1.3",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.0.4"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             }
         },
         "chownr": {
@@ -969,8 +969,8 @@
             "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "clap": {
@@ -979,7 +979,7 @@
             "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.1.3"
             }
         },
         "class-utils": {
@@ -988,10 +988,10 @@
             "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1000,7 +1000,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1009,7 +1009,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1018,7 +1018,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1029,7 +1029,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1038,7 +1038,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1049,9 +1049,9 @@
                     "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -1068,7 +1068,7 @@
             "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "0.5.x"
             }
         },
         "cli-table": {
@@ -1094,8 +1094,8 @@
             "integrity": "sha1-6vHJ1bkeIkgjMwcqEhJ/Bc2Zo7o=",
             "dev": true,
             "requires": {
-                "marked": "0.3.19",
-                "marked-terminal": "2.0.0"
+                "marked": "^0.3.12",
+                "marked-terminal": "^2.0.0"
             }
         },
         "cliui": {
@@ -1104,8 +1104,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "dev": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             }
         },
@@ -1133,9 +1133,9 @@
             "integrity": "sha1-1ZHe5Kj4vBXaQ86X3O66E9Q+KmU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "isarray": {
@@ -1150,13 +1150,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -1165,7 +1165,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -1182,7 +1182,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -1197,8 +1197,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color": {
@@ -1207,9 +1207,9 @@
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "color-convert": "1.9.1",
-                "color-string": "0.3.0"
+                "clone": "^1.0.2",
+                "color-convert": "^1.3.0",
+                "color-string": "^0.3.0"
             }
         },
         "color-convert": {
@@ -1218,7 +1218,7 @@
             "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -1233,7 +1233,7 @@
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.0.0"
             }
         },
         "color-support": {
@@ -1248,9 +1248,9 @@
             "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
             "dev": true,
             "requires": {
-                "color": "0.11.4",
+                "color": "^0.11.0",
                 "css-color-names": "0.0.4",
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "colors": {
@@ -1282,7 +1282,7 @@
             "resolved": "http://r.cnpmjs.org/compressible/download/compressible-2.0.13.tgz",
             "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": ">= 1.33.0 < 2"
             }
         },
         "compression": {
@@ -1290,13 +1290,13 @@
             "resolved": "http://r.cnpmjs.org/compression/download/compression-1.7.2.tgz",
             "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "bytes": "3.0.0",
-                "compressible": "2.0.13",
+                "compressible": "~2.0.13",
                 "debug": "2.6.9",
-                "on-headers": "1.0.1",
+                "on-headers": "~1.0.1",
                 "safe-buffer": "5.1.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             }
         },
         "concat-map": {
@@ -1311,10 +1311,10 @@
             "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
             "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             },
             "dependencies": {
                 "isarray": {
@@ -1329,13 +1329,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -1344,7 +1344,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -1355,7 +1355,7 @@
             "integrity": "sha1-iWS8I0fQWBm2N5gQTYfW4AG+2NA=",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1372,7 +1372,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "console-stamp": {
@@ -1380,9 +1380,9 @@
             "resolved": "http://r.cnpmjs.org/console-stamp/download/console-stamp-0.2.6.tgz",
             "integrity": "sha1-mqIblFt4jWOc49H5sc0cWn7MlsA=",
             "requires": {
-                "chalk": "1.1.3",
-                "dateformat": "1.0.12",
-                "merge": "1.2.0"
+                "chalk": "^1.1.1",
+                "dateformat": "^1.0.11",
+                "merge": "^1.2.0"
             },
             "dependencies": {
                 "dateformat": {
@@ -1390,8 +1390,8 @@
                     "resolved": "http://r.cnpmjs.org/dateformat/download/dateformat-1.0.12.tgz",
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 }
             }
@@ -1443,12 +1443,12 @@
             "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
             }
         },
         "copy-descriptor": {
@@ -1463,14 +1463,14 @@
             "integrity": "sha1-/E9o9K3YN8xeE9ERsgcVeTIl0pw=",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "globby": "7.1.1",
-                "is-glob": "4.0.0",
-                "loader-utils": "1.1.0",
-                "minimatch": "3.0.4",
-                "p-limit": "1.2.0",
-                "serialize-javascript": "1.4.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "globby": "^7.1.1",
+                "is-glob": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "minimatch": "^3.0.4",
+                "p-limit": "^1.0.0",
+                "serialize-javascript": "^1.4.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -1479,9 +1479,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -1509,8 +1509,8 @@
             "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-hash": {
@@ -1519,10 +1519,10 @@
             "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -1531,12 +1531,12 @@
             "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "crypto-browserify": {
@@ -1545,17 +1545,17 @@
             "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.0",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.0",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "diffie-hellman": "5.0.2",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
-                "public-encrypt": "4.0.0",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css-color-names": {
@@ -1570,18 +1570,18 @@
             "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "css-selector-tokenizer": "0.7.0",
-                "cssnano": "3.10.0",
-                "loader-utils": "1.1.0",
-                "lodash.camelcase": "4.3.0",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-modules-extract-imports": "1.1.0",
-                "postcss-modules-local-by-default": "1.2.0",
-                "postcss-modules-scope": "1.1.0",
-                "postcss-modules-values": "1.3.0",
-                "source-list-map": "0.1.8"
+                "babel-code-frame": "^6.11.0",
+                "css-selector-tokenizer": "^0.7.0",
+                "cssnano": ">=2.6.1 <4",
+                "loader-utils": "^1.0.2",
+                "lodash.camelcase": "^4.3.0",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.6",
+                "postcss-modules-extract-imports": "^1.0.0",
+                "postcss-modules-local-by-default": "^1.0.1",
+                "postcss-modules-scope": "^1.0.0",
+                "postcss-modules-values": "^1.1.0",
+                "source-list-map": "^0.1.7"
             },
             "dependencies": {
                 "loader-utils": {
@@ -1590,9 +1590,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "object-assign": {
@@ -1609,10 +1609,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-selector-tokenizer": {
@@ -1621,9 +1621,9 @@
             "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
             "dev": true,
             "requires": {
-                "cssesc": "0.1.0",
-                "fastparse": "1.1.1",
-                "regexpu-core": "1.0.0"
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
             }
         },
         "css-what": {
@@ -1644,38 +1644,38 @@
             "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
             "dev": true,
             "requires": {
-                "autoprefixer": "6.7.7",
-                "decamelize": "1.2.0",
-                "defined": "1.0.0",
-                "has": "1.0.1",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-calc": "5.3.1",
-                "postcss-colormin": "2.2.2",
-                "postcss-convert-values": "2.6.1",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-discard-duplicates": "2.1.0",
-                "postcss-discard-empty": "2.1.0",
-                "postcss-discard-overridden": "0.1.1",
-                "postcss-discard-unused": "2.2.3",
-                "postcss-filter-plugins": "2.0.2",
-                "postcss-merge-idents": "2.1.7",
-                "postcss-merge-longhand": "2.0.2",
-                "postcss-merge-rules": "2.1.2",
-                "postcss-minify-font-values": "1.0.5",
-                "postcss-minify-gradients": "1.0.5",
-                "postcss-minify-params": "1.2.2",
-                "postcss-minify-selectors": "2.1.1",
-                "postcss-normalize-charset": "1.1.1",
-                "postcss-normalize-url": "3.0.8",
-                "postcss-ordered-values": "2.2.3",
-                "postcss-reduce-idents": "2.4.0",
-                "postcss-reduce-initial": "1.0.1",
-                "postcss-reduce-transforms": "1.0.4",
-                "postcss-svgo": "2.1.6",
-                "postcss-unique-selectors": "2.0.2",
-                "postcss-value-parser": "3.3.0",
-                "postcss-zindex": "2.2.0"
+                "autoprefixer": "^6.3.1",
+                "decamelize": "^1.1.2",
+                "defined": "^1.0.0",
+                "has": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.14",
+                "postcss-calc": "^5.2.0",
+                "postcss-colormin": "^2.1.8",
+                "postcss-convert-values": "^2.3.4",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-discard-duplicates": "^2.0.1",
+                "postcss-discard-empty": "^2.0.1",
+                "postcss-discard-overridden": "^0.1.1",
+                "postcss-discard-unused": "^2.2.1",
+                "postcss-filter-plugins": "^2.0.0",
+                "postcss-merge-idents": "^2.1.5",
+                "postcss-merge-longhand": "^2.0.1",
+                "postcss-merge-rules": "^2.0.3",
+                "postcss-minify-font-values": "^1.0.2",
+                "postcss-minify-gradients": "^1.0.1",
+                "postcss-minify-params": "^1.0.4",
+                "postcss-minify-selectors": "^2.0.4",
+                "postcss-normalize-charset": "^1.1.0",
+                "postcss-normalize-url": "^3.0.7",
+                "postcss-ordered-values": "^2.1.0",
+                "postcss-reduce-idents": "^2.2.2",
+                "postcss-reduce-initial": "^1.0.0",
+                "postcss-reduce-transforms": "^1.0.3",
+                "postcss-svgo": "^2.1.1",
+                "postcss-unique-selectors": "^2.0.2",
+                "postcss-value-parser": "^3.2.3",
+                "postcss-zindex": "^2.0.1"
             },
             "dependencies": {
                 "object-assign": {
@@ -1692,8 +1692,8 @@
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "dev": true,
             "requires": {
-                "clap": "1.2.3",
-                "source-map": "0.5.7"
+                "clap": "^1.0.9",
+                "source-map": "^0.5.3"
             }
         },
         "currently-unhandled": {
@@ -1701,7 +1701,7 @@
             "resolved": "http://r.cnpmjs.org/currently-unhandled/download/currently-unhandled-0.4.1.tgz",
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "cyclist": {
@@ -1747,7 +1747,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4"
+                "clone": "^1.0.2"
             }
         },
         "define-properties": {
@@ -1756,8 +1756,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -1766,8 +1766,8 @@
             "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             }
         },
         "defined": {
@@ -1782,13 +1782,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "globby": {
@@ -1797,12 +1797,12 @@
                     "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "arrify": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "object-assign": {
@@ -1830,8 +1830,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -1851,9 +1851,9 @@
             "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "dir-glob": {
@@ -1862,8 +1862,8 @@
             "integrity": "sha1-CyBdK2rvmCOMooZZioIE0p0KADQ=",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             },
             "dependencies": {
                 "path-type": {
@@ -1872,7 +1872,7 @@
                     "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
                     "dev": true,
                     "requires": {
-                        "pify": "3.0.0"
+                        "pify": "^3.0.0"
                     }
                 },
                 "pify": {
@@ -1889,7 +1889,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "0.3.3"
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -1906,8 +1906,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1936,7 +1936,7 @@
             "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1945,8 +1945,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -1961,7 +1961,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             }
         },
         "duplexify": {
@@ -1970,10 +1970,10 @@
             "integrity": "sha1-S7RsF5bqvr7sTKmi5muAjLej2LQ=",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -1988,13 +1988,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2003,7 +2003,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -2025,13 +2025,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "emojis-list": {
@@ -2051,7 +2051,7 @@
             "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -2060,10 +2060,10 @@
             "integrity": "sha1-lQlk7MfwMypCMhtnOzjcj/FVNbM=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "memory-fs": "0.4.1",
-                "object-assign": "4.1.1",
-                "tapable": "0.2.8"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "object-assign": "^4.0.1",
+                "tapable": "^0.2.5"
             },
             "dependencies": {
                 "object-assign": {
@@ -2086,7 +2086,7 @@
             "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
             "dev": true,
             "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
             }
         },
         "error-ex": {
@@ -2094,7 +2094,7 @@
             "resolved": "http://r.cnpmjs.org/error-ex/download/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "errorhandler": {
@@ -2102,8 +2102,8 @@
             "resolved": "http://r.cnpmjs.org/errorhandler/download/errorhandler-1.5.0.tgz",
             "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
             "requires": {
-                "accepts": "1.3.5",
-                "escape-html": "1.0.3"
+                "accepts": "~1.3.3",
+                "escape-html": "~1.0.3"
             }
         },
         "es6-templates": {
@@ -2112,8 +2112,8 @@
             "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
             "dev": true,
             "requires": {
-                "recast": "0.11.23",
-                "through": "2.3.8"
+                "recast": "~0.11.12",
+                "through": "~2.3.6"
             }
         },
         "escape-html": {
@@ -2148,13 +2148,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "events": {
@@ -2169,8 +2169,8 @@
             "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "expand-brackets": {
@@ -2179,13 +2179,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2194,7 +2194,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -2203,7 +2203,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2212,7 +2212,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2221,7 +2221,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2232,7 +2232,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2241,7 +2241,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2252,9 +2252,9 @@
                     "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -2271,7 +2271,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "express": {
@@ -2279,36 +2279,36 @@
             "resolved": "http://r.cnpmjs.org/express/download/express-4.16.3.tgz",
             "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.3",
+                "proxy-addr": "~2.0.3",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0",
-                "type-is": "1.6.16",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "statuses": {
@@ -2327,10 +2327,10 @@
                 "cookie-signature": "1.0.6",
                 "crc": "3.4.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "on-headers": "1.0.1",
-                "parseurl": "1.3.2",
-                "uid-safe": "2.1.5",
+                "depd": "~1.1.1",
+                "on-headers": "~1.0.1",
+                "parseurl": "~1.3.2",
+                "uid-safe": "~2.1.5",
                 "utils-merge": "1.0.1"
             }
         },
@@ -2346,8 +2346,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -2356,7 +2356,7 @@
                     "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -2367,14 +2367,14 @@
             "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2383,7 +2383,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -2392,7 +2392,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -2403,10 +2403,10 @@
             "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.3.0",
-                "webpack-sources": "1.1.0"
+                "async": "^2.1.2",
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^0.3.0",
+                "webpack-sources": "^1.0.1"
             },
             "dependencies": {
                 "async": {
@@ -2415,7 +2415,7 @@
                     "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.5"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "loader-utils": {
@@ -2424,9 +2424,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -2437,9 +2437,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -2466,7 +2466,7 @@
             "integrity": "sha1-HS2t3UJM5tGwfP4/eXMb7TYXq0I=",
             "dev": true,
             "requires": {
-                "loader-utils": "0.2.17"
+                "loader-utils": "~0.2.5"
             }
         },
         "file-saver": {
@@ -2480,10 +2480,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2492,7 +2492,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -2503,12 +2503,12 @@
             "integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.4.0",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.4.0",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "statuses": {
@@ -2524,9 +2524,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "1.2.0",
-                "pkg-dir": "2.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
             }
         },
         "find-index": {
@@ -2540,8 +2540,8 @@
             "resolved": "http://r.cnpmjs.org/find-up/download/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -2550,10 +2550,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "is-glob": {
@@ -2562,7 +2562,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2573,11 +2573,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -2604,8 +2604,8 @@
             "integrity": "sha1-xdWG7zivYJdlC0m8QbVfq7GfNb0=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             },
             "dependencies": {
                 "isarray": {
@@ -2620,13 +2620,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2635,7 +2635,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -2652,7 +2652,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -2678,7 +2678,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -2698,8 +2698,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -2714,13 +2714,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2729,7 +2729,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -2740,8 +2740,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "through2": "2.0.3"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs-write-stream-atomic": {
@@ -2750,10 +2750,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "1.1.14"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
             }
         },
         "fs.realpath": {
@@ -2769,8 +2769,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.39"
             },
             "dependencies": {
                 "abbrev": {
@@ -2785,8 +2785,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -2807,8 +2807,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -2853,7 +2853,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
@@ -2862,7 +2862,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
@@ -2871,7 +2871,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
@@ -2880,7 +2880,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2914,7 +2914,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -2941,7 +2941,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
@@ -2950,7 +2950,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -3000,7 +3000,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -3044,10 +3044,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
@@ -3056,9 +3056,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -3067,14 +3067,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
@@ -3083,7 +3083,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -3100,12 +3100,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -3142,10 +3142,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -3160,9 +3160,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
@@ -3171,8 +3171,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -3220,7 +3220,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -3241,7 +3241,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -3327,17 +3327,17 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
+                        "detect-libc": "^1.0.2",
                         "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
                         "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^2.2.1",
+                        "tar-pack": "^3.4.0"
                     }
                 },
                 "nopt": {
@@ -3356,10 +3356,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -3386,7 +3386,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -3447,10 +3447,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -3467,13 +3467,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
@@ -3482,28 +3482,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
@@ -3512,7 +3512,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -3545,7 +3545,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
@@ -3554,15 +3554,15 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -3579,9 +3579,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -3590,7 +3590,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -3605,7 +3605,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -3620,9 +3620,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
@@ -3631,14 +3631,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
@@ -3647,7 +3647,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -3656,7 +3656,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -3698,7 +3698,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -3721,7 +3721,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "0.1.0"
+                "globule": "~0.1.0"
             }
         },
         "get-caller-file": {
@@ -3747,12 +3747,12 @@
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -3761,8 +3761,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -3771,7 +3771,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -3782,12 +3782,12 @@
             "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
             "dev": true,
             "requires": {
-                "glob": "4.5.3",
-                "glob2base": "0.0.12",
-                "minimatch": "2.0.10",
-                "ordered-read-streams": "0.1.0",
-                "through2": "0.6.5",
-                "unique-stream": "1.0.0"
+                "glob": "^4.3.1",
+                "glob2base": "^0.0.12",
+                "minimatch": "^2.0.1",
+                "ordered-read-streams": "^0.1.0",
+                "through2": "^0.6.1",
+                "unique-stream": "^1.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -3796,10 +3796,10 @@
                     "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^2.0.1",
+                        "once": "^1.3.0"
                     }
                 },
                 "minimatch": {
@@ -3808,7 +3808,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -3817,10 +3817,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "through2": {
@@ -3829,8 +3829,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -3841,7 +3841,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "0.5.2"
+                "gaze": "^0.5.1"
             }
         },
         "glob2base": {
@@ -3850,7 +3850,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-modules": {
@@ -3859,9 +3859,9 @@
             "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -3870,11 +3870,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.0"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -3883,12 +3883,12 @@
             "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "dir-glob": "2.0.0",
-                "glob": "7.1.2",
-                "ignore": "3.3.7",
-                "pify": "3.0.0",
-                "slash": "1.0.0"
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -3905,9 +3905,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "3.1.21",
-                "lodash": "1.0.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.1.21",
+                "lodash": "~1.0.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -3916,9 +3916,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "1.2.3",
-                        "inherits": "1.0.2",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~1.2.0",
+                        "inherits": "1",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -3951,8 +3951,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -3963,7 +3963,7 @@
             "integrity": "sha1-3PdY5EeJzD89MsHzVio2duajSBA=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -3983,19 +3983,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "chalk": "1.1.3",
-                "deprecated": "0.0.1",
-                "gulp-util": "3.0.8",
-                "interpret": "1.1.0",
-                "liftoff": "2.5.0",
-                "minimist": "1.2.0",
-                "orchestrator": "0.3.8",
-                "pretty-hrtime": "1.0.3",
-                "semver": "4.3.6",
-                "tildify": "1.2.0",
-                "v8flags": "2.1.1",
-                "vinyl-fs": "0.3.14"
+                "archy": "^1.0.0",
+                "chalk": "^1.0.0",
+                "deprecated": "^0.0.1",
+                "gulp-util": "^3.0.0",
+                "interpret": "^1.0.0",
+                "liftoff": "^2.1.0",
+                "minimist": "^1.1.0",
+                "orchestrator": "^0.3.0",
+                "pretty-hrtime": "^1.0.0",
+                "semver": "^4.1.0",
+                "tildify": "^1.0.0",
+                "v8flags": "^2.0.2",
+                "vinyl-fs": "^0.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -4012,11 +4012,11 @@
             "integrity": "sha1-KuSBCf6DzMln/1rVPARJSaSGOzY=",
             "dev": true,
             "requires": {
-                "clean-css": "4.1.11",
-                "gulp-util": "3.0.8",
-                "object-assign": "4.1.1",
-                "through2": "2.0.3",
-                "vinyl-sourcemaps-apply": "0.2.1"
+                "clean-css": "^4.0.4",
+                "gulp-util": "^3.0.8",
+                "object-assign": "^4.1.1",
+                "through2": "^2.0.3",
+                "vinyl-sourcemaps-apply": "^0.2.1"
             },
             "dependencies": {
                 "object-assign": {
@@ -4033,9 +4033,9 @@
             "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
             "dev": true,
             "requires": {
-                "concat-with-sourcemaps": "1.0.5",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "concat-with-sourcemaps": "^1.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^2.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -4062,12 +4062,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -4078,8 +4078,8 @@
             "integrity": "sha1-INHJA56T9qfDw8yE1VepBSwjDPQ=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "lodash": "4.17.5"
+                "gulp-util": "^3.0.3",
+                "lodash": "^4.13.1"
             }
         },
         "gulp-if": {
@@ -4088,9 +4088,9 @@
             "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
             "dev": true,
             "requires": {
-                "gulp-match": "1.0.3",
-                "ternary-stream": "2.0.1",
-                "through2": "2.0.3"
+                "gulp-match": "^1.0.3",
+                "ternary-stream": "^2.0.1",
+                "through2": "^2.0.1"
             }
         },
         "gulp-match": {
@@ -4099,7 +4099,7 @@
             "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
             "dev": true,
             "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.3"
             }
         },
         "gulp-uglify": {
@@ -4108,14 +4108,14 @@
             "integrity": "sha1-bbhbHQ7mPRgFhZK2WGSdZcLsRUE=",
             "dev": true,
             "requires": {
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash": "4.17.5",
-                "make-error-cause": "1.2.2",
-                "through2": "2.0.3",
-                "uglify-js": "2.8.29",
-                "uglify-save-license": "0.4.1",
-                "vinyl-sourcemaps-apply": "0.2.1"
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash": "^4.13.1",
+                "make-error-cause": "^1.1.1",
+                "through2": "^2.0.0",
+                "uglify-js": "~2.8.10",
+                "uglify-save-license": "^0.4.1",
+                "vinyl-sourcemaps-apply": "^0.2.0"
             }
         },
         "gulp-useref": {
@@ -4124,16 +4124,16 @@
             "integrity": "sha1-vrjgCcGfgZ9gTejRkdsSi9JEqnA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "extend": "3.0.1",
-                "glob": "7.1.2",
-                "gulp-concat": "2.6.1",
-                "gulp-if": "2.0.2",
+                "event-stream": "^3.3.4",
+                "extend": "^3.0.1",
+                "glob": "^7.1.2",
+                "gulp-concat": "^2.6.1",
+                "gulp-if": "^2.0.2",
                 "is-relative-url": "1.0.0",
-                "plugin-error": "1.0.1",
-                "through2": "2.0.3",
-                "useref": "1.4.1",
-                "vinyl-fs": "3.0.2"
+                "plugin-error": "^1.0.1",
+                "through2": "^2.0.3",
+                "useref": "^1.4.1",
+                "vinyl-fs": "^3.0.2"
             },
             "dependencies": {
                 "clone": {
@@ -4154,16 +4154,16 @@
                     "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "7.1.2",
-                        "glob-parent": "3.1.0",
-                        "is-negated-glob": "1.0.0",
-                        "ordered-read-streams": "1.0.1",
-                        "pumpify": "1.4.0",
-                        "readable-stream": "2.3.5",
-                        "remove-trailing-separator": "1.1.0",
-                        "to-absolute-glob": "2.0.2",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^7.1.1",
+                        "glob-parent": "^3.1.0",
+                        "is-negated-glob": "^1.0.0",
+                        "ordered-read-streams": "^1.0.0",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.1.5",
+                        "remove-trailing-separator": "^1.0.1",
+                        "to-absolute-glob": "^2.0.0",
+                        "unique-stream": "^2.0.2"
                     }
                 },
                 "isarray": {
@@ -4178,7 +4178,7 @@
                     "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.5"
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "readable-stream": {
@@ -4187,13 +4187,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "replace-ext": {
@@ -4208,7 +4208,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "unique-stream": {
@@ -4217,8 +4217,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "1.0.1",
-                        "through2-filter": "2.0.0"
+                        "json-stable-stringify": "^1.0.0",
+                        "through2-filter": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -4227,12 +4227,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 },
                 "vinyl-fs": {
@@ -4241,23 +4241,23 @@
                     "integrity": "sha1-G4YliEQ4P1dYH8qsCB/gnvbW11I=",
                     "dev": true,
                     "requires": {
-                        "fs-mkdirp-stream": "1.0.0",
-                        "glob-stream": "6.1.0",
-                        "graceful-fs": "4.1.11",
-                        "is-valid-glob": "1.0.0",
-                        "lazystream": "1.0.0",
-                        "lead": "1.0.0",
-                        "object.assign": "4.1.0",
-                        "pumpify": "1.4.0",
-                        "readable-stream": "2.3.5",
-                        "remove-bom-buffer": "3.0.0",
-                        "remove-bom-stream": "1.2.0",
-                        "resolve-options": "1.1.0",
-                        "through2": "2.0.3",
-                        "to-through": "2.0.0",
-                        "value-or-function": "3.0.0",
-                        "vinyl": "2.1.0",
-                        "vinyl-sourcemap": "1.1.0"
+                        "fs-mkdirp-stream": "^1.0.0",
+                        "glob-stream": "^6.1.0",
+                        "graceful-fs": "^4.0.0",
+                        "is-valid-glob": "^1.0.0",
+                        "lazystream": "^1.0.0",
+                        "lead": "^1.0.0",
+                        "object.assign": "^4.0.4",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.3.3",
+                        "remove-bom-buffer": "^3.0.0",
+                        "remove-bom-stream": "^1.2.0",
+                        "resolve-options": "^1.1.0",
+                        "through2": "^2.0.0",
+                        "to-through": "^2.0.0",
+                        "value-or-function": "^3.0.0",
+                        "vinyl": "^2.0.0",
+                        "vinyl-sourcemap": "^1.1.0"
                     }
                 }
             }
@@ -4268,24 +4268,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             }
         },
         "gulplog": {
@@ -4294,7 +4294,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "has": {
@@ -4303,7 +4303,7 @@
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.0.2"
             }
         },
         "has-ansi": {
@@ -4311,7 +4311,7 @@
             "resolved": "http://r.cnpmjs.org/has-ansi/download/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -4326,7 +4326,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -4341,9 +4341,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -4352,8 +4352,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4362,7 +4362,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4373,7 +4373,7 @@
             "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "^2.0.1"
             }
         },
         "hash.js": {
@@ -4382,8 +4382,8 @@
             "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "he": {
@@ -4398,9 +4398,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "homedir-polyfill": {
@@ -4409,7 +4409,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -4429,11 +4429,11 @@
             "integrity": "sha1-X7zYfNY6XEmn/OL+VvQl4Fcpxow=",
             "dev": true,
             "requires": {
-                "es6-templates": "0.2.3",
-                "fastparse": "1.1.1",
-                "html-minifier": "3.5.12",
-                "loader-utils": "1.1.0",
-                "object-assign": "4.1.1"
+                "es6-templates": "^0.2.2",
+                "fastparse": "^1.1.1",
+                "html-minifier": "^3.0.1",
+                "loader-utils": "^1.0.2",
+                "object-assign": "^4.1.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -4442,9 +4442,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "object-assign": {
@@ -4461,14 +4461,14 @@
             "integrity": "sha1-a/rU0DJ/W40rYvWFRlSsNwO5sDE=",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.1.11",
-                "commander": "2.15.1",
-                "he": "1.1.1",
-                "ncname": "1.0.0",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.3.17"
+                "camel-case": "3.0.x",
+                "clean-css": "4.1.x",
+                "commander": "2.15.x",
+                "he": "1.1.x",
+                "ncname": "1.0.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.3.x"
             },
             "dependencies": {
                 "source-map": {
@@ -4483,8 +4483,8 @@
                     "integrity": "sha1-8ypmsZH+GKW2tLZrdcChlfeBH54=",
                     "dev": true,
                     "requires": {
-                        "commander": "2.15.1",
-                        "source-map": "0.6.1"
+                        "commander": "~2.15.0",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -4495,12 +4495,12 @@
             "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "html-minifier": "3.5.12",
-                "loader-utils": "0.2.17",
-                "lodash": "4.17.5",
-                "pretty-error": "2.1.1",
-                "toposort": "1.0.6"
+                "bluebird": "^3.4.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "toposort": "^1.0.0"
             }
         },
         "htmlparser2": {
@@ -4509,10 +4509,10 @@
             "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.1.0",
-                "domutils": "1.1.6",
-                "readable-stream": "1.0.34"
+                "domelementtype": "1",
+                "domhandler": "2.1",
+                "domutils": "1.1",
+                "readable-stream": "1.0"
             },
             "dependencies": {
                 "domutils": {
@@ -4521,7 +4521,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "readable-stream": {
@@ -4530,10 +4530,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 }
             }
@@ -4543,10 +4543,10 @@
             "resolved": "http://r.cnpmjs.org/http-errors/download/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.5.0"
+                "statuses": ">= 1.4.0 < 2"
             }
         },
         "https-browserify": {
@@ -4600,7 +4600,7 @@
             "resolved": "http://r.cnpmjs.org/indent-string/download/indent-string-2.1.0.tgz",
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "indexes-of": {
@@ -4621,8 +4621,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -4659,8 +4659,8 @@
             "integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-absolute-url": {
@@ -4675,7 +4675,7 @@
             "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             }
         },
         "is-arrayish": {
@@ -4689,7 +4689,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -4703,7 +4703,7 @@
             "resolved": "http://r.cnpmjs.org/is-builtin-module/download/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -4712,7 +4712,7 @@
             "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             }
         },
         "is-descriptor": {
@@ -4721,9 +4721,9 @@
             "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             }
         },
         "is-extendable": {
@@ -4743,7 +4743,7 @@
             "resolved": "http://r.cnpmjs.org/is-finite/download/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -4752,7 +4752,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -4761,7 +4761,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-negated-glob": {
@@ -4776,7 +4776,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4785,7 +4785,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4796,7 +4796,7 @@
             "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -4819,7 +4819,7 @@
             "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -4828,7 +4828,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -4843,7 +4843,7 @@
             "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-relative": {
@@ -4852,7 +4852,7 @@
             "integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-relative-url": {
@@ -4861,7 +4861,7 @@
             "integrity": "sha1-h6nTXop4m0ngebTX1p1kYS6ODh8=",
             "dev": true,
             "requires": {
-                "is-absolute-url": "1.0.0"
+                "is-absolute-url": "^1.0.0"
             },
             "dependencies": {
                 "is-absolute-url": {
@@ -4878,7 +4878,7 @@
             "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
             "dev": true,
             "requires": {
-                "html-comment-regex": "1.1.1"
+                "html-comment-regex": "^1.1.0"
             }
         },
         "is-unc-path": {
@@ -4887,7 +4887,7 @@
             "integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -4976,7 +4976,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json5": {
@@ -5009,7 +5009,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             },
             "dependencies": {
                 "isarray": {
@@ -5024,13 +5024,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -5039,7 +5039,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -5050,7 +5050,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "lead": {
@@ -5059,7 +5059,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.3"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "lie": {
@@ -5067,7 +5067,7 @@
             "resolved": "http://r.cnpmjs.org/lie/download/lie-3.1.1.tgz",
             "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
             "requires": {
-                "immediate": "3.0.6"
+                "immediate": "~3.0.5"
             }
         },
         "liftoff": {
@@ -5076,14 +5076,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.6.0"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "light-reload": {
@@ -5092,7 +5092,7 @@
             "integrity": "sha1-DzPLoL8wmYgHKC8t+9j55RIqF/Q=",
             "dev": true,
             "requires": {
-                "ws": "1.1.5"
+                "ws": "^1.1.1"
             }
         },
         "load-json-file": {
@@ -5100,11 +5100,11 @@
             "resolved": "http://r.cnpmjs.org/load-json-file/download/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "loader-runner": {
@@ -5119,10 +5119,10 @@
             "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
             "dev": true,
             "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1",
-                "object-assign": "4.1.1"
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0",
+                "object-assign": "^4.0.1"
             },
             "dependencies": {
                 "object-assign": {
@@ -5147,8 +5147,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             },
             "dependencies": {
                 "path-exists": {
@@ -5183,8 +5183,8 @@
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash.keys": "3.1.2"
+                "lodash._basecopy": "^3.0.0",
+                "lodash.keys": "^3.0.0"
             }
         },
         "lodash._baseclone": {
@@ -5193,12 +5193,12 @@
             "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
             "dev": true,
             "requires": {
-                "lodash._arraycopy": "3.0.0",
-                "lodash._arrayeach": "3.0.0",
-                "lodash._baseassign": "3.2.0",
-                "lodash._basefor": "3.0.3",
-                "lodash.isarray": "3.0.4",
-                "lodash.keys": "3.1.2"
+                "lodash._arraycopy": "^3.0.0",
+                "lodash._arrayeach": "^3.0.0",
+                "lodash._baseassign": "^3.0.0",
+                "lodash._basefor": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.keys": "^3.0.0"
             }
         },
         "lodash._basecopy": {
@@ -5285,8 +5285,8 @@
             "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
             "dev": true,
             "requires": {
-                "lodash._baseclone": "3.3.0",
-                "lodash._bindcallback": "3.0.1"
+                "lodash._baseclone": "^3.0.0",
+                "lodash._bindcallback": "^3.0.0"
             }
         },
         "lodash.escape": {
@@ -5295,7 +5295,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -5316,9 +5316,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.memoize": {
@@ -5339,15 +5339,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -5356,8 +5356,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "lodash.toarray": {
@@ -5383,8 +5383,8 @@
             "resolved": "http://r.cnpmjs.org/loud-rejection/download/loud-rejection-1.6.0.tgz",
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lower-case": {
@@ -5399,8 +5399,8 @@
             "integrity": "sha1-RSNLLm4vKzPaElYkxGZJKaAiTD8=",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "macaddress": {
@@ -5415,7 +5415,7 @@
             "integrity": "sha1-bWpJ7q1KrilsU7vzoaAIvWyJRps=",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5438,7 +5438,7 @@
             "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
             "dev": true,
             "requires": {
-                "make-error": "1.3.4"
+                "make-error": "^1.2.0"
             }
         },
         "make-iterator": {
@@ -5447,7 +5447,7 @@
             "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5456,7 +5456,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5484,7 +5484,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "marked": {
@@ -5499,11 +5499,11 @@
             "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
             "dev": true,
             "requires": {
-                "cardinal": "1.0.0",
-                "chalk": "1.1.3",
-                "cli-table": "0.3.1",
-                "lodash.assign": "4.2.0",
-                "node-emoji": "1.8.1"
+                "cardinal": "^1.0.0",
+                "chalk": "^1.1.3",
+                "cli-table": "^0.3.1",
+                "lodash.assign": "^4.2.0",
+                "node-emoji": "^1.4.1"
             }
         },
         "math-expression-evaluator": {
@@ -5518,8 +5518,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             },
             "dependencies": {
                 "hash-base": {
@@ -5528,8 +5528,8 @@
                     "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "safe-buffer": "5.1.1"
+                        "inherits": "^2.0.1",
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -5545,8 +5545,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "readable-stream": "2.3.5"
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -5561,13 +5561,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -5576,7 +5576,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -5586,16 +5586,16 @@
             "resolved": "http://r.cnpmjs.org/meow/download/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -5621,7 +5621,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -5636,13 +5636,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -5651,7 +5651,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -5667,19 +5667,19 @@
             "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.1",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "miller-rabin": {
@@ -5688,8 +5688,8 @@
             "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -5707,7 +5707,7 @@
             "resolved": "http://r.cnpmjs.org/mime-types/download/mime-types-2.1.18.tgz",
             "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "minimalistic-assert": {
@@ -5728,7 +5728,7 @@
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -5742,16 +5742,16 @@
             "integrity": "sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "duplexify": "3.5.4",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.3",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
             }
         },
         "mixin-deep": {
@@ -5760,8 +5760,8 @@
             "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5770,7 +5770,7 @@
                     "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5796,12 +5796,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "copy-concurrently": "1.0.5",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
             }
         },
         "ms": {
@@ -5831,25 +5831,24 @@
             "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "natives": {
-            "version": "1.1.2",
-            "resolved": "http://r.cnpmjs.org/natives/download/natives-1.1.2.tgz",
-            "integrity": "sha1-RDfKHtin8EdTHM368nkoU99O+hw=",
-            "dev": true
+            "version": "1.1.6",
+            "resolved": "https://registry-npm.rd.chanjet.com/natives/download/natives-1.1.6.tgz",
+            "integrity": "sha1-pgO0pJirdxc2ErnqGs3sTZgPALs="
         },
         "ncname": {
             "version": "1.0.0",
@@ -5857,7 +5856,7 @@
             "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
             "dev": true,
             "requires": {
-                "xml-char-classes": "1.0.0"
+                "xml-char-classes": "^1.0.0"
             }
         },
         "nedb": {
@@ -5867,9 +5866,9 @@
             "requires": {
                 "async": "0.2.10",
                 "binary-search-tree": "0.2.5",
-                "localforage": "1.7.1",
-                "mkdirp": "0.5.1",
-                "underscore": "1.4.4"
+                "localforage": "^1.3.0",
+                "mkdirp": "~0.5.1",
+                "underscore": "~1.4.4"
             }
         },
         "nedb-session-store": {
@@ -5877,7 +5876,7 @@
             "resolved": "http://r.cnpmjs.org/nedb-session-store/download/nedb-session-store-1.1.2.tgz",
             "integrity": "sha1-JQeIV1TLQF1ienVOiQPsea3KyQY=",
             "requires": {
-                "nedb": "1.8.0"
+                "nedb": "^1.5.0"
             }
         },
         "negotiator": {
@@ -5897,8 +5896,8 @@
             "integrity": "sha1-dUQObCa015cxSpUx5K7Unrr22n8=",
             "dev": true,
             "requires": {
-                "@types/jquery": "2.0.49",
-                "@types/select2": "4.0.44"
+                "@types/jquery": "^2.0.39",
+                "@types/select2": "^4.0.31"
             }
         },
         "ngx-bootstrap": {
@@ -5912,7 +5911,7 @@
             "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-emoji": {
@@ -5921,7 +5920,7 @@
             "integrity": "sha1-buxr+wdCHiFIx1xrunJCH4UwqCY=",
             "dev": true,
             "requires": {
-                "lodash.toarray": "4.4.0"
+                "lodash.toarray": "^4.4.0"
             }
         },
         "node-libs-browser": {
@@ -5930,28 +5929,28 @@
             "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.5",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.1",
-                "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.6",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.3",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -5967,13 +5966,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     },
                     "dependencies": {
                         "string_decoder": {
@@ -5982,7 +5981,7 @@
                             "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "5.1.1"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -5993,7 +5992,7 @@
                     "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -6004,13 +6003,13 @@
             "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
             "dev": true,
             "requires": {
-                "cli-usage": "0.1.7",
-                "growly": "1.3.0",
-                "lodash.clonedeep": "3.0.2",
-                "minimist": "1.2.0",
-                "semver": "5.5.0",
-                "shellwords": "0.1.1",
-                "which": "1.3.0"
+                "cli-usage": "^0.1.1",
+                "growly": "^1.2.0",
+                "lodash.clonedeep": "^3.0.0",
+                "minimist": "^1.1.1",
+                "semver": "^5.1.0",
+                "shellwords": "^0.1.0",
+                "which": "^1.0.5"
             }
         },
         "normalize-package-data": {
@@ -6018,10 +6017,10 @@
             "resolved": "http://r.cnpmjs.org/normalize-package-data/download/normalize-package-data-2.4.0.tgz",
             "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -6030,7 +6029,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -6045,10 +6044,10 @@
             "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prepend-http": "1.0.4",
-                "query-string": "4.3.4",
-                "sort-keys": "1.1.2"
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -6065,7 +6064,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "nth-check": {
@@ -6074,7 +6073,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "num2fraction": {
@@ -6100,9 +6099,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -6111,7 +6110,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6120,7 +6119,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -6129,7 +6128,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -6138,9 +6137,9 @@
                     "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6157,7 +6156,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6174,7 +6173,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -6183,10 +6182,10 @@
             "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.11"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -6195,10 +6194,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "object.map": {
@@ -6207,8 +6206,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.pick": {
@@ -6217,7 +6216,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "on-finished": {
@@ -6239,7 +6238,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "options": {
@@ -6254,9 +6253,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "0.1.5",
-                "sequencify": "0.0.7",
-                "stream-consume": "0.1.1"
+                "end-of-stream": "~0.1.5",
+                "sequencify": "~0.0.7",
+                "stream-consume": "~0.1.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -6265,7 +6264,7 @@
                     "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
                     "dev": true,
                     "requires": {
-                        "once": "1.3.3"
+                        "once": "~1.3.0"
                     }
                 },
                 "once": {
@@ -6274,7 +6273,7 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -6303,7 +6302,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "p-limit": {
@@ -6312,7 +6311,7 @@
             "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -6321,7 +6320,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-try": {
@@ -6342,9 +6341,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
             },
             "dependencies": {
                 "isarray": {
@@ -6359,13 +6358,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -6374,7 +6373,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -6385,7 +6384,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "parse-asn1": {
@@ -6394,11 +6393,11 @@
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.1.1",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-filepath": {
@@ -6407,9 +6406,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-json": {
@@ -6417,7 +6416,7 @@
             "resolved": "http://r.cnpmjs.org/parse-json/download/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -6454,7 +6453,7 @@
             "resolved": "http://r.cnpmjs.org/path-exists/download/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -6481,7 +6480,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -6500,9 +6499,9 @@
             "resolved": "http://r.cnpmjs.org/path-type/download/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "pause-stream": {
@@ -6511,7 +6510,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pbkdf2": {
@@ -6520,11 +6519,11 @@
             "integrity": "sha1-o14TxkeZsGzhUyD0WcIw5o5zut4=",
             "dev": true,
             "requires": {
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "pify": {
@@ -6542,7 +6541,7 @@
             "resolved": "http://r.cnpmjs.org/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -6551,7 +6550,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -6560,7 +6559,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 }
             }
@@ -6571,10 +6570,10 @@
             "integrity": "sha1-dwFr2JGdCsN3/c3QMiMolTyleBw=",
             "dev": true,
             "requires": {
-                "ansi-colors": "1.1.0",
-                "arr-diff": "4.0.0",
-                "arr-union": "3.1.0",
-                "extend-shallow": "3.0.2"
+                "ansi-colors": "^1.0.1",
+                "arr-diff": "^4.0.0",
+                "arr-union": "^3.1.0",
+                "extend-shallow": "^3.0.2"
             }
         },
         "posix-character-classes": {
@@ -6589,10 +6588,10 @@
             "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.4.3",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
             },
             "dependencies": {
                 "has-flag": {
@@ -6607,7 +6606,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -6618,9 +6617,9 @@
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-message-helpers": "2.0.0",
-                "reduce-css-calc": "1.3.0"
+                "postcss": "^5.0.2",
+                "postcss-message-helpers": "^2.0.0",
+                "reduce-css-calc": "^1.2.6"
             }
         },
         "postcss-colormin": {
@@ -6629,9 +6628,9 @@
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "dev": true,
             "requires": {
-                "colormin": "1.1.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "colormin": "^1.0.5",
+                "postcss": "^5.0.13",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "postcss-convert-values": {
@@ -6640,8 +6639,8 @@
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.11",
+                "postcss-value-parser": "^3.1.2"
             }
         },
         "postcss-discard-comments": {
@@ -6650,7 +6649,7 @@
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             }
         },
         "postcss-discard-duplicates": {
@@ -6659,7 +6658,7 @@
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-discard-empty": {
@@ -6668,7 +6667,7 @@
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             }
         },
         "postcss-discard-overridden": {
@@ -6677,7 +6676,7 @@
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.16"
             }
         },
         "postcss-discard-unused": {
@@ -6686,8 +6685,8 @@
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "postcss": "^5.0.14",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-filter-plugins": {
@@ -6696,8 +6695,8 @@
             "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqid": "4.1.1"
+                "postcss": "^5.0.4",
+                "uniqid": "^4.0.0"
             }
         },
         "postcss-merge-idents": {
@@ -6706,9 +6705,9 @@
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.10",
+                "postcss-value-parser": "^3.1.1"
             }
         },
         "postcss-merge-longhand": {
@@ -6717,7 +6716,7 @@
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-merge-rules": {
@@ -6726,11 +6725,11 @@
             "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-api": "1.6.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
+                "browserslist": "^1.5.2",
+                "caniuse-api": "^1.5.2",
+                "postcss": "^5.0.4",
+                "postcss-selector-parser": "^2.2.2",
+                "vendors": "^1.0.0"
             }
         },
         "postcss-message-helpers": {
@@ -6745,9 +6744,9 @@
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             },
             "dependencies": {
                 "object-assign": {
@@ -6764,8 +6763,8 @@
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.12",
+                "postcss-value-parser": "^3.3.0"
             }
         },
         "postcss-minify-params": {
@@ -6774,10 +6773,10 @@
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.2",
+                "postcss-value-parser": "^3.0.2",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-minify-selectors": {
@@ -6786,10 +6785,10 @@
             "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3"
+                "alphanum-sort": "^1.0.2",
+                "has": "^1.0.1",
+                "postcss": "^5.0.14",
+                "postcss-selector-parser": "^2.0.0"
             }
         },
         "postcss-modules-extract-imports": {
@@ -6798,7 +6797,7 @@
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.21"
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6807,7 +6806,7 @@
                     "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -6816,9 +6815,9 @@
                     "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "postcss": {
@@ -6827,9 +6826,9 @@
                     "integrity": "sha1-gmVmJpTt356aWWDbbaM8OeTNBp0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "source-map": {
@@ -6844,7 +6843,7 @@
                     "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -6855,8 +6854,8 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.21"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6865,7 +6864,7 @@
                     "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -6874,9 +6873,9 @@
                     "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "postcss": {
@@ -6885,9 +6884,9 @@
                     "integrity": "sha1-gmVmJpTt356aWWDbbaM8OeTNBp0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "source-map": {
@@ -6902,7 +6901,7 @@
                     "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -6913,8 +6912,8 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.21"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6923,7 +6922,7 @@
                     "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -6932,9 +6931,9 @@
                     "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "postcss": {
@@ -6943,9 +6942,9 @@
                     "integrity": "sha1-gmVmJpTt356aWWDbbaM8OeTNBp0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "source-map": {
@@ -6960,7 +6959,7 @@
                     "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -6971,8 +6970,8 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.21"
+                "icss-replace-symbols": "^1.1.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6981,7 +6980,7 @@
                     "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -6990,9 +6989,9 @@
                     "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "postcss": {
@@ -7001,9 +7000,9 @@
                     "integrity": "sha1-gmVmJpTt356aWWDbbaM8OeTNBp0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "source-map": {
@@ -7018,7 +7017,7 @@
                     "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -7029,7 +7028,7 @@
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.5"
             }
         },
         "postcss-normalize-url": {
@@ -7038,10 +7037,10 @@
             "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
             "dev": true,
             "requires": {
-                "is-absolute-url": "2.1.0",
-                "normalize-url": "1.9.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^1.4.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "postcss-ordered-values": {
@@ -7050,8 +7049,8 @@
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.1"
             }
         },
         "postcss-reduce-idents": {
@@ -7060,8 +7059,8 @@
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             }
         },
         "postcss-reduce-initial": {
@@ -7070,7 +7069,7 @@
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-reduce-transforms": {
@@ -7079,9 +7078,9 @@
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.8",
+                "postcss-value-parser": "^3.0.1"
             }
         },
         "postcss-selector-parser": {
@@ -7090,9 +7089,9 @@
             "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
             "dev": true,
             "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-svgo": {
@@ -7101,10 +7100,10 @@
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "dev": true,
             "requires": {
-                "is-svg": "2.1.0",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "svgo": "0.7.2"
+                "is-svg": "^2.0.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3",
+                "svgo": "^0.7.0"
             }
         },
         "postcss-unique-selectors": {
@@ -7113,9 +7112,9 @@
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-value-parser": {
@@ -7130,9 +7129,9 @@
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             }
         },
         "prepend-http": {
@@ -7147,8 +7146,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "2.0.1",
-                "utila": "0.4.0"
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
             }
         },
         "pretty-hrtime": {
@@ -7187,9 +7186,9 @@
             "integrity": "sha1-T4ASiEQ8VewCmyDL/cvz4dwX+FI=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "object.assign": "4.1.0",
-                "progress": "1.1.8"
+                "chalk": "^1.1.1",
+                "object.assign": "^4.0.1",
+                "progress": "^1.1.8"
             }
         },
         "promise-inflight": {
@@ -7203,7 +7202,7 @@
             "resolved": "http://r.cnpmjs.org/proxy-addr/download/proxy-addr-2.0.3.tgz",
             "integrity": "sha1-NV8mJQWmIWRrMTCnKOtkfiIFU0E=",
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.6.0"
             }
         },
@@ -7225,11 +7224,11 @@
             "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "parse-asn1": "5.1.0",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pump": {
@@ -7238,8 +7237,8 @@
             "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -7248,9 +7247,9 @@
             "integrity": "sha1-gLfF334kFT0D8OesigWl0Gi9B/s=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -7276,8 +7275,8 @@
             "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -7311,7 +7310,7 @@
             "integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -7320,8 +7319,8 @@
             "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.1"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -7353,7 +7352,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.5.0"
+                        "statuses": ">= 1.3.1 < 2"
                     }
                 },
                 "setprototypeof": {
@@ -7374,9 +7373,9 @@
             "resolved": "http://r.cnpmjs.org/read-pkg/download/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -7384,8 +7383,8 @@
             "resolved": "http://r.cnpmjs.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -7394,10 +7393,10 @@
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
             }
         },
         "readdirp": {
@@ -7406,10 +7405,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.5",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -7424,13 +7423,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -7439,7 +7438,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -7451,9 +7450,9 @@
             "dev": true,
             "requires": {
                 "ast-types": "0.9.6",
-                "esprima": "3.1.3",
-                "private": "0.1.8",
-                "source-map": "0.5.7"
+                "esprima": "~3.1.0",
+                "private": "~0.1.5",
+                "source-map": "~0.5.0"
             },
             "dependencies": {
                 "esprima": {
@@ -7470,7 +7469,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.6.0"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -7478,8 +7477,8 @@
             "resolved": "http://r.cnpmjs.org/redent/download/redent-1.0.0.tgz",
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
             }
         },
         "redeyed": {
@@ -7488,7 +7487,7 @@
             "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
             "dev": true,
             "requires": {
-                "esprima": "3.0.0"
+                "esprima": "~3.0.0"
             },
             "dependencies": {
                 "esprima": {
@@ -7505,9 +7504,9 @@
             "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2",
-                "math-expression-evaluator": "1.2.17",
-                "reduce-function-call": "1.0.2"
+                "balanced-match": "^0.4.2",
+                "math-expression-evaluator": "^1.2.14",
+                "reduce-function-call": "^1.0.1"
             },
             "dependencies": {
                 "balanced-match": {
@@ -7524,7 +7523,7 @@
             "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2"
+                "balanced-match": "^0.4.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -7553,8 +7552,8 @@
             "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpu-core": {
@@ -7563,9 +7562,9 @@
             "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
             "dev": true,
             "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
             }
         },
         "regjsgen": {
@@ -7580,7 +7579,7 @@
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             }
         },
         "relateurl": {
@@ -7595,8 +7594,8 @@
             "integrity": "sha1-wr8eN3Ug0yT2I4kuM8EMrCwlK1M=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -7605,9 +7604,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.1",
-                "through2": "2.0.3"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -7622,11 +7621,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-converter": "0.1.4",
-                "htmlparser2": "3.3.0",
-                "strip-ansi": "3.0.1",
-                "utila": "0.3.3"
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.1",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -7654,7 +7653,7 @@
             "resolved": "http://r.cnpmjs.org/repeating/download/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -7681,7 +7680,7 @@
             "integrity": "sha1-D70hJ4sntABEgcOVNJ56umCp/1w=",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -7690,8 +7689,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-options": {
@@ -7700,7 +7699,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -7721,7 +7720,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -7730,7 +7729,7 @@
             "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -7739,8 +7738,8 @@
             "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
             "dev": true,
             "requires": {
-                "hash-base": "2.0.2",
-                "inherits": "2.0.3"
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "run-queue": {
@@ -7749,7 +7748,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
             }
         },
         "run-sequence": {
@@ -7758,8 +7757,8 @@
             "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "gulp-util": "3.0.8"
+                "chalk": "*",
+                "gulp-util": "*"
             }
         },
         "rxjs": {
@@ -7782,7 +7781,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "sax": {
@@ -7797,7 +7796,7 @@
             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2"
+                "ajv": "^5.0.0"
             }
         },
         "semver": {
@@ -7811,18 +7810,18 @@
             "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.3",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.4.0"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
             },
             "dependencies": {
                 "statuses": {
@@ -7849,9 +7848,9 @@
             "resolved": "http://r.cnpmjs.org/serve-static/download/serve-static-1.13.2.tgz",
             "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -7873,10 +7872,10 @@
             "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -7885,7 +7884,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -7907,8 +7906,8 @@
             "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shellwords": {
@@ -7940,14 +7939,14 @@
             "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -7956,7 +7955,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -7965,7 +7964,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -7974,7 +7973,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7983,7 +7982,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -7994,7 +7993,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -8003,7 +8002,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -8014,9 +8013,9 @@
                     "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -8033,9 +8032,9 @@
             "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -8044,7 +8043,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -8055,7 +8054,7 @@
             "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -8064,7 +8063,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -8075,7 +8074,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "source-list-map": {
@@ -8096,11 +8095,11 @@
             "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
             "dev": true,
             "requires": {
-                "atob": "2.1.0",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -8109,7 +8108,7 @@
             "integrity": "sha1-VEVu+onKqScK981iTMLxI+Ufuug=",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -8137,8 +8136,8 @@
             "resolved": "http://r.cnpmjs.org/spdx-correct/download/spdx-correct-3.0.0.tgz",
             "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -8151,8 +8150,8 @@
             "resolved": "http://r.cnpmjs.org/spdx-expression-parse/download/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -8166,7 +8165,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -8175,7 +8174,7 @@
             "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -8189,7 +8188,7 @@
             "integrity": "sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.1"
             }
         },
         "static-extend": {
@@ -8198,8 +8197,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -8208,7 +8207,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -8217,7 +8216,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -8226,7 +8225,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -8237,7 +8236,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -8246,7 +8245,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -8257,9 +8256,9 @@
                     "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -8281,8 +8280,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             },
             "dependencies": {
                 "isarray": {
@@ -8297,13 +8296,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -8312,7 +8311,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -8323,7 +8322,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-consume": {
@@ -8338,8 +8337,8 @@
             "integrity": "sha1-joxGP5HaiZF3h2WHP+TZYNj2Fr0=",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "stream-http": {
@@ -8348,11 +8347,11 @@
             "integrity": "sha1-0EQb4aRXpzpzOop7U1cL69nvZqQ=",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.3",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -8367,13 +8366,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -8382,7 +8381,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -8405,9 +8404,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -8421,7 +8420,7 @@
             "resolved": "http://r.cnpmjs.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -8429,7 +8428,7 @@
             "resolved": "http://r.cnpmjs.org/strip-bom/download/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-indent": {
@@ -8437,7 +8436,7 @@
             "resolved": "http://r.cnpmjs.org/strip-indent/download/strip-indent-1.0.1.tgz",
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
             }
         },
         "style-loader": {
@@ -8446,7 +8445,7 @@
             "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.0.2"
             },
             "dependencies": {
                 "loader-utils": {
@@ -8455,9 +8454,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -8473,13 +8472,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
             },
             "dependencies": {
                 "esprima": {
@@ -8518,10 +8517,10 @@
             "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "fork-stream": "0.0.4",
-                "merge-stream": "1.0.1",
-                "through2": "2.0.3"
+                "duplexify": "^3.5.0",
+                "fork-stream": "^0.0.4",
+                "merge-stream": "^1.0.0",
+                "through2": "^2.0.1"
             }
         },
         "through": {
@@ -8536,8 +8535,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -8552,13 +8551,13 @@
                     "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.0.3",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -8567,7 +8566,7 @@
                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -8578,8 +8577,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "tildify": {
@@ -8588,7 +8587,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "time-stamp": {
@@ -8603,7 +8602,7 @@
             "integrity": "sha1-JB52kn2coF9NlZgZAi9bNmS2S64=",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "to-absolute-glob": {
@@ -8612,8 +8611,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "is-negated-glob": "1.0.0"
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-arraybuffer": {
@@ -8628,7 +8627,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -8637,7 +8636,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -8648,10 +8647,10 @@
             "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -8660,8 +8659,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "to-through": {
@@ -8670,7 +8669,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.3"
             }
         },
         "toposort": {
@@ -8702,7 +8701,7 @@
             "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.18"
+                "mime-types": "~2.1.18"
             }
         },
         "typedarray": {
@@ -8723,9 +8722,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             }
         },
         "uglify-save-license": {
@@ -8746,7 +8745,7 @@
             "resolved": "http://r.cnpmjs.org/uid-safe/download/uid-safe-2.1.5.tgz",
             "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
             "requires": {
-                "random-bytes": "1.0.0"
+                "random-bytes": "~1.0.0"
             }
         },
         "ultron": {
@@ -8772,10 +8771,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -8784,7 +8783,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -8793,10 +8792,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -8813,7 +8812,7 @@
             "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
             "dev": true,
             "requires": {
-                "macaddress": "0.2.8"
+                "macaddress": "^0.2.8"
             }
         },
         "uniqs": {
@@ -8828,7 +8827,7 @@
             "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "dev": true,
             "requires": {
-                "unique-slug": "2.0.0"
+                "unique-slug": "^2.0.0"
             }
         },
         "unique-slug": {
@@ -8837,7 +8836,7 @@
             "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
             "dev": true,
             "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
             }
         },
         "unique-stream": {
@@ -8857,8 +8856,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -8867,9 +8866,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -8939,7 +8938,7 @@
             "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "user-home": {
@@ -8999,7 +8998,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "validate-npm-package-license": {
@@ -9007,8 +9006,8 @@
             "resolved": "http://r.cnpmjs.org/validate-npm-package-license/download/validate-npm-package-license-3.0.3.tgz",
             "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "value-or-function": {
@@ -9034,8 +9033,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -9045,14 +9044,14 @@
             "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
             "dev": true,
             "requires": {
-                "defaults": "1.0.3",
-                "glob-stream": "3.1.18",
-                "glob-watcher": "0.0.6",
-                "graceful-fs": "3.0.11",
-                "mkdirp": "0.5.1",
-                "strip-bom": "1.0.0",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "defaults": "^1.0.0",
+                "glob-stream": "^3.1.5",
+                "glob-watcher": "^0.0.6",
+                "graceful-fs": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "strip-bom": "^1.0.0",
+                "through2": "^0.6.1",
+                "vinyl": "^0.4.0"
             },
             "dependencies": {
                 "clone": {
@@ -9067,7 +9066,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.2"
+                        "natives": "^1.1.0"
                     }
                 },
                 "readable-stream": {
@@ -9076,10 +9075,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "strip-bom": {
@@ -9088,8 +9087,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "1.0.0",
-                        "is-utf8": "0.2.1"
+                        "first-chunk-stream": "^1.0.0",
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "through2": {
@@ -9098,8 +9097,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -9108,8 +9107,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -9120,13 +9119,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.1.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -9153,12 +9152,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -9169,7 +9168,7 @@
             "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.1"
             }
         },
         "vm-browserify": {
@@ -9187,9 +9186,9 @@
             "integrity": "sha1-Ix54Ovgwoi+JZvZcTEusyBQHLu0=",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.3",
-                "graceful-fs": "4.1.11",
-                "neo-async": "2.5.0"
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
             }
         },
         "webpack": {
@@ -9198,27 +9197,27 @@
             "integrity": "sha1-sqEiaAQ3P/09A+qca9UlBnA09rE=",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "acorn-dynamic-import": "2.0.2",
-                "ajv": "4.11.8",
-                "ajv-keywords": "1.5.1",
-                "async": "2.6.0",
-                "enhanced-resolve": "3.3.0",
-                "interpret": "1.1.0",
-                "json-loader": "0.5.7",
-                "json5": "0.5.1",
-                "loader-runner": "2.3.0",
-                "loader-utils": "0.2.17",
-                "memory-fs": "0.4.1",
-                "mkdirp": "0.5.1",
-                "node-libs-browser": "2.1.0",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3",
-                "tapable": "0.2.8",
-                "uglify-js": "2.8.29",
-                "watchpack": "1.5.0",
-                "webpack-sources": "1.1.0",
-                "yargs": "6.6.0"
+                "acorn": "^5.0.0",
+                "acorn-dynamic-import": "^2.0.0",
+                "ajv": "^4.7.0",
+                "ajv-keywords": "^1.1.1",
+                "async": "^2.1.2",
+                "enhanced-resolve": "^3.3.0",
+                "interpret": "^1.0.0",
+                "json-loader": "^0.5.4",
+                "json5": "^0.5.1",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^0.2.16",
+                "memory-fs": "~0.4.1",
+                "mkdirp": "~0.5.0",
+                "node-libs-browser": "^2.0.0",
+                "source-map": "^0.5.3",
+                "supports-color": "^3.1.0",
+                "tapable": "~0.2.5",
+                "uglify-js": "^2.8.27",
+                "watchpack": "^1.3.1",
+                "webpack-sources": "^1.0.1",
+                "yargs": "^6.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -9227,8 +9226,8 @@
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "async": {
@@ -9237,7 +9236,7 @@
                     "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.5"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "camelcase": {
@@ -9252,9 +9251,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "has-flag": {
@@ -9269,7 +9268,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 },
                 "y18n": {
@@ -9284,19 +9283,19 @@
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "4.2.1"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.2.0"
                     }
                 }
             }
@@ -9307,7 +9306,7 @@
             "integrity": "sha1-8dgB0sXTn4P/7J8RkkCz476ZShw=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "^4.17.4"
             }
         },
         "webpack-sources": {
@@ -9316,8 +9315,8 @@
             "integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
             "dev": true,
             "requires": {
-                "source-list-map": "2.0.0",
-                "source-map": "0.6.1"
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "source-list-map": {
@@ -9346,7 +9345,7 @@
             "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -9373,8 +9372,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -9389,8 +9388,8 @@
             "integrity": "sha1-y9nm514J/F0skAFfIfDECHXg3VE=",
             "dev": true,
             "requires": {
-                "options": "0.0.6",
-                "ultron": "1.0.2"
+                "options": ">=0.0.5",
+                "ultron": "1.0.x"
             }
         },
         "xml-char-classes": {
@@ -9423,9 +9422,9 @@
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "dev": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             },
             "dependencies": {
@@ -9443,7 +9442,7 @@
             "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2106,6 +2106,11 @@
                 "escape-html": "~1.0.3"
             }
         },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry-npm.rd.chanjet.com/es6-promise/download/es6-promise-4.2.8.tgz",
+            "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+        },
         "es6-templates": {
             "version": "0.2.3",
             "resolved": "http://r.cnpmjs.org/es6-templates/download/es6-templates-0.2.3.tgz",
@@ -2315,6 +2320,31 @@
                     "version": "1.4.0",
                     "resolved": "http://r.cnpmjs.org/statuses/download/statuses-1.4.0.tgz",
                     "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+                }
+            }
+        },
+        "express-http-proxy": {
+            "version": "1.6.2",
+            "resolved": "https://registry-npm.rd.chanjet.com/express-http-proxy/download/express-http-proxy-1.6.2.tgz",
+            "integrity": "sha1-6HFS5FlYzuS5HaL9qiCh/9WBIEo=",
+            "requires": {
+                "debug": "^3.0.1",
+                "es6-promise": "^4.1.1",
+                "raw-body": "^2.3.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry-npm.rd.chanjet.com/debug/download/debug-3.2.7.tgz",
+                    "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry-npm.rd.chanjet.com/ms/download/ms-2.1.2.tgz",
+                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "express-session": "^1.15.1",
         "file-saver": "^1.3.8",
         "js-yaml": "^3.13.1",
+        "natives": "^1.1.6",
         "nedb": "^1.8.0",
         "nedb-session-store": "^1.1.1",
         "ngx-bootstrap": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "cookie-parser": "^1.4.3",
         "errorhandler": "^1.5.0",
         "express": "^4.15.2",
+        "express-http-proxy": "^1.6.2",
         "express-session": "^1.15.1",
         "file-saver": "^1.3.8",
         "js-yaml": "^3.13.1",

--- a/src/client/app/pages/cluster/container-info/container-info.page.ts
+++ b/src/client/app/pages/cluster/container-info/container-info.page.ts
@@ -202,7 +202,9 @@ export class ClusterContainerInfoPage {
   private upgrade(form: any) {
     this.upgradeContainerModalOptions.formSubmitted = true;
     if (form.invalid) return;
-    let newImage = `${this.container.Config.Image.split(':')[0]}:${form.value.newTag}`;
+    let tempPaths = this.container.Config.Image.split('/');
+    tempPaths[tempPaths.length-1] = `${tempPaths[tempPaths.length-1].split(':')[0]}:${form.value.newTag}`;
+    let newImage = tempPaths.join('/');
     this._clusterService.upgradeImage(this.metaId, form.value.newTag)
       .then(res => {
         messager.success('succeed');

--- a/src/client/app/pages/cluster/overview/overview.component.ts
+++ b/src/client/app/pages/cluster/overview/overview.component.ts
@@ -317,7 +317,9 @@ export class ClusterOverviewPage {
   private upgrade(form: any) {
     this.upgradeContainerModalOptions.formSubmitted = true;
     if (form.invalid) return;
-    let newImage = `${this.upgradeContainerTarget.Config.Image.split(':')[0]}:${form.value.newTag}`;
+    let tempPaths = this.upgradeContainerTarget.Config.Image.split('/');
+    tempPaths[tempPaths.length-1] = `${tempPaths[tempPaths.length-1].split(':')[0]}:${form.value.newTag}`;
+    let newImage = tempPaths.join('/');
     this._clusterService.upgradeImage(this.upgradeContainerTarget.MetaId, form.value.newTag)
       .then(res => {
         messager.success('succeed');

--- a/src/client/app/pages/group/server/component-new/component-new.page.ts
+++ b/src/client/app/pages/group/server/component-new/component-new.page.ts
@@ -164,7 +164,7 @@ export class ComponentNewPage {
     this.checkComposeData(true);
     if (this.composeDataError && this.composeDataError !== 'succeed') return;
     if (this.inputValue && form.controls.EnablePackageFile.value) {
-      this._fileUploader.upload(`http://${this.ip}:8500/dockerapi/v2/services/${form.controls.Name.value}/upload?filename=${this.inputValue.name}`, this.inputValue, { disableLoading: false })
+      this._fileUploader.upload(`/proxy/${this.ip}:8500/dockerapi/v2/services/${form.controls.Name.value}/upload?filename=${this.inputValue.name}`, this.inputValue, { disableLoading: false })
         .then((res: any) => {
           let config: any = {
             Name: form.value.Name,

--- a/src/client/app/pages/group/server/container-detail/container-detail.page.ts
+++ b/src/client/app/pages/group/server/container-detail/container-detail.page.ts
@@ -243,7 +243,9 @@ export class ContainerDetailPage {
     this.upgradeContainerModalOptions.formSubmitted = true;
     if (form.invalid || !this.selectedServers.length) return;
     let destTag = form.value.newTag;
-    let image = `${this.container.Config.Image.split(':')[0]}:${destTag}`;
+    let tempPaths = this.container.Config.Image.split('/');
+    tempPaths[tempPaths.length-1] = `${tempPaths[tempPaths.length-1].split(':')[0]}:${destTag}`;
+    let image = tempPaths.join('/');
 
     this.upgradeContainerModalOptions.show = false;
     this.upgradeProgressModalOptions.show = true;

--- a/src/client/app/pages/group/server/container-monitor/container-monitor.page.ts
+++ b/src/client/app/pages/group/server/container-monitor/container-monitor.page.ts
@@ -46,7 +46,7 @@ export class ContainerMonitorPage {
       this.containerId = params['containerId'];
       clearInterval(this.refreshInterval);
     });
-    this.subscribers.push(paramSub);    
+    this.subscribers.push(paramSub);
   }
 
   ngOnDestroy() {
@@ -173,7 +173,7 @@ export class ContainerMonitorPage {
   private updateChart() {
     let time = new Date();
     let self = this;
-    let url = `http://${this.ip}:8500/v1/containers/${this.containerId}/stats`;
+    let url = `/proxy/${this.ip}:8500/v1/containers/${this.containerId}/stats`;
     fetch(url)
       .then((res: any) => {
         res.json().then((data: any) => {

--- a/src/client/app/services/compose.service.ts
+++ b/src/client/app/services/compose.service.ts
@@ -30,7 +30,7 @@ export class ComposeService {
         'x-proxy-ip': ip
       };
     }
-    let url: string = `http://${ip}:8500/dockerapi/v2`;
+    let url: string = `/proxy/${ip}:8500/dockerapi/v2`;
     let req = {
       url: url,
       options: options

--- a/src/client/app/services/container.service.ts
+++ b/src/client/app/services/container.service.ts
@@ -23,7 +23,7 @@ export class ContainerService {
         'x-proxy-ip': ip
       };
     }
-    let url: string = `http://${ip}:8500/dockerapi/v2`;
+    let url: string = `/proxy/${ip}:8500/dockerapi/v2`;
     let req = {
       url: url,
       options: options

--- a/src/client/app/services/image.service.ts
+++ b/src/client/app/services/image.service.ts
@@ -29,7 +29,7 @@ export class ImageService {
         'x-proxy-ip': ip
       };
     }
-    let url: string = `http://${ip}:8500/dockerapi/v2`;
+    let url: string = `/proxy/${ip}:8500/dockerapi/v2`;
     let req = {
       url: url,
       options: options

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -8,7 +8,7 @@ if (process.env.ENV === 'production') {
   enableProdMode();
 } else {
   require('light-reload/client');
-  lightReload.init(9107, { maxReconnectCount: 10 });
+  lightReload.init(process.env.WS_PORT || 9107, { maxReconnectCount: 10, wsUrl: process.env.WS_URL });
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ const session = require('express-session');
 const errorHandler = require('errorhandler');
 require("console-stamp")(console, 'yyyy/mm/dd HH:MM:ss.l');
 const NedbStore = require('nedb-session-store')(session);
+const proxy = require('express-http-proxy');
 
 const user = require('./controllers/user');
 const config = require('./config.js');
@@ -89,6 +90,18 @@ app.use('/api/images', require('./routers/imageInfo'));
 app.use('/api/logs', require('./routers/log'));
 app.use('/api/system-config', require('./routers/systemConfig'));
 app.use('/api/dashboard', require('./routers/dashboard'));
+
+// proxy to agent api
+app.use('/proxy', proxy((req)=>{
+  const paths = req.path.split('/');
+  return 'http://' + paths[2];
+},{
+  proxyReqPathResolver:(req)=>{
+    const paths = req.path.split('/');
+    paths.splice(1,2);
+    return paths.join('/');
+  }
+}));
 
 errorHandler.title = `Humpback WebSite - ${config.version}`;
 app.use(errorHandler({ log: false }));

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -38,7 +38,7 @@ app.use(compression());
 app.use((req, res, next) => {
   let ext = path.extname(req.url);
   if (ext && ext.length > 6) ext = null;
-  if (req.method === 'GET' && !req.url.startsWith('/api') && !ext) {
+  if (req.method === 'GET' && !req.url.startsWith('/api') && !req.url.startsWith('/api') && !ext) {
     req.url = '/index.html';
   }
   next();
@@ -94,11 +94,11 @@ app.use('/api/dashboard', require('./routers/dashboard'));
 // proxy to agent api
 app.use('/proxy', proxy((req)=>{
   const paths = req.path.split('/');
-  return 'http://' + paths[2];
+  return 'http://' + paths[1];
 },{
   proxyReqPathResolver:(req)=>{
     const paths = req.path.split('/');
-    paths.splice(1,2);
+    paths.splice(1,1);
     return paths.join('/');
   }
 }));


### PR DESCRIPTION
1、修复支持私有仓库带有一个端口时拆分镜像名成了ip地址的问题
2、增加了/proxy接口，转发到内网agent，使其可以在外网访问（私有仓库和cluster都可以通过配置nginx解决外网访问和安全问题）